### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Dependancies
 
 ```
 python3 -m pip install -U discord.py
-python3 -m pip install -U fuzzywuzzy
+python3 -m pip install -U rapidfuzz
 ```
 
 ## Bot Commands

--- a/cogs/img.py
+++ b/cogs/img.py
@@ -6,7 +6,7 @@ import discord.ext.commands
 import sqlite3
 from discord.ext import commands
 from discord.utils import get
-from fuzzywuzzy import process, fuzz
+from rapidfuzz import process, fuzz
 import re
 from res.common import sanitise_input, ship_search, customemoji
 from res.data import ShipData

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 discord
-fuzzywuzzy
+rapidfuzz

--- a/res/common.py
+++ b/res/common.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import sqlite3
-from fuzzywuzzy import process
+from rapidfuzz import process
 import unicodedata
 import re
 import discord.ext.commands
@@ -30,7 +30,7 @@ def ship_search(find_this):
     # using the class initiated list ship_list find one ship name that 
     # matches the given string as close as possible
     found_this = process.extractOne(find_this, get_ships())
-    # fuzzywuzzy returns the name and the ratio so strip the ratio and keep 
+    # rapidfuzz returns the name and the ratio so strip the ratio and keep 
     # the ship name
     ship_name = found_this[0]
     # return the ship name as a string
@@ -57,7 +57,7 @@ def invader_search(find_this):
         # using the class initiated list ship_list find one ship name that 
         # matches the given string as close as possible
         found_this = process.extractOne(find_this, get_invaders())
-        # fuzzywuzzy returns the name and the ratio so strip the ratio and keep 
+        # rapidfuzz returns the name and the ratio so strip the ratio and keep 
         # the ship name
         invader_name = found_this[0]
         # return the ship name as a string

--- a/res/invaders.py
+++ b/res/invaders.py
@@ -5,7 +5,7 @@ import discord.ext.commands
 from discord.ext import commands
 from discord.utils import get
 from res.common import customemoji
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 class invader_type():
     def __init__(self, bot_self, sub_command, arg1):
@@ -37,7 +37,7 @@ class invader_type():
             # using the class initiated list ship_list find one ship name that 
             # matches the given string as close as possible
             found_this = process.extractOne(find_this, self.get_invaders())
-            # fuzzywuzzy returns the name and the ratio so strip the ratio and keep 
+            # rapidfuzz returns the name and the ratio so strip the ratio and keep 
             # the ship name
             invader_name = found_this[0]
             # return the ship name as a string


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy